### PR TITLE
Show numeric IDs in nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ x{N-1} y{N-1} [label{N-1}]
 - The first line contains `N`, the number of nodes (nodes are assumed to be numbered 1..N).
 - The next `N-1` lines describe edges. Each line contains the source and target node numbers separated by spaces and an optional third value used as the edge label.
 - Optionally, the following `N` lines specify labels for nodes 1..N. If these lines are omitted, nodes will be labeled with their number.
+- Nodes always display their numeric id inside the circle while any provided label appears just below the node.
 
 After parsing the input, the graph will appear in the SVG area. Nodes can be dragged around and the edges will follow.
 

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
  textarea {width: 100%; height: 8em;}
  .node circle {fill: #69b3a2; stroke: #333; stroke-width: 1.5px;}
  .node text {pointer-events: none; font-size: 12px; text-anchor: middle; fill: #000;}
+ .node-label {fill: #000;}
  .link line {stroke: #999; stroke-width: 1.5px;}
  .link text {font-size: 10px; fill: #555;}
 </style>
@@ -68,13 +69,20 @@ function drawGraph(data) {
  link.append('line');
  link.append('text').text(d => d.label || '');
 
- const node = nodeGroup.selectAll('g').data(data.nodes).enter()
-   .append('g').attr('class', 'node').call(d3.drag()
-     .on('start', dragstarted)
-     .on('drag', dragged)
-     .on('end', dragended));
- node.append('circle').attr('r', 15);
- node.append('text').attr('dy', 4).text(d => d.label);
+  const node = nodeGroup.selectAll('g').data(data.nodes).enter()
+    .append('g').attr('class', 'node').call(d3.drag()
+      .on('start', dragstarted)
+      .on('drag', dragged)
+      .on('end', dragended));
+  node.append('circle').attr('r', 15);
+  node.append('text')
+    .attr('class', 'node-id')
+    .attr('dy', 4)
+    .text(d => d.id);
+  node.append('text')
+    .attr('class', 'node-label')
+    .attr('dy', 24)
+    .text(d => d.label);
 
  simulation.on('tick', () => {
    link.select('line')


### PR DESCRIPTION
## Summary
- show node numbers in the circle and move labels below
- note node number display in README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a0eb053a88320995c0e4efd79f41f